### PR TITLE
Fix issue: Crashing when logging out

### DIFF
--- a/11-performantly-render-large-list-of-items-with-react-context/src/index.js
+++ b/11-performantly-render-large-list-of-items-with-react-context/src/index.js
@@ -14,7 +14,7 @@ function Root() {
         user ? (
           <MainPage />
         ) : (
-          <LoginPage onLogin={this.handleLogin} />
+          <LoginPage />
         )
       }
     </UserConsumer>


### PR DESCRIPTION
Remove onLogin={this.handleLogin} from <Login/>, as you get it from context and primarily because it was crashing the app when you logout.